### PR TITLE
Fix: Declare $id and $desc properties explicitly to resolve PHP 8.2+ …

### DIFF
--- a/guest-order-tracking-for-woocommerce.php
+++ b/guest-order-tracking-for-woocommerce.php
@@ -3,13 +3,13 @@
 Plugin Name: Guest Order Tracking for WooCommerce
 Plugin URI: https://wordpress.org/plugins/guest-order-tracking-for-woocommerce/
 Description: Makes it easier for unlogged users to access a WooCommerce order.
-Version: 2.1.7
+Version: 2.1.8
 Author: WPFactory
 Author URI: https://wpfactory.com
 Text Domain: guest-order-tracking-for-woocommerce
 Domain Path: /langs
 WC requires at least: 3.0.0
-WC tested up to: 10.1
+WC tested up to: 10.6
 Requires Plugins: woocommerce
 */
 
@@ -33,7 +33,7 @@ final class Alg_WC_Guest_Order_Tracking {
 	 * @var   string
 	 * @since 2.0.0
 	 */
-	public $version = '2.1.7';
+	public $version = '2.1.8';
 
 	/**
 	 * @var   Alg_WC_Guest_Order_Tracking The single instance of the class

--- a/includes/settings/class-alg-wc-guest-order-tracking-settings-section.php
+++ b/includes/settings/class-alg-wc-guest-order-tracking-settings-section.php
@@ -2,7 +2,7 @@
 /**
  * Guest Order Tracking for WooCommerce - Section Settings
  *
- * @version 2.0.0
+ * @version 2.1.8
  * @since   2.0.0
  *
  * @author  WPFactory
@@ -13,14 +13,22 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 if ( ! class_exists( 'Alg_WC_Guest_Order_Tracking_Settings_Section' ) ) :
 
 class Alg_WC_Guest_Order_Tracking_Settings_Section {
-	
+
 	/**
-	 * FIX: PHP 8.2+ এ dynamic property deprecated।
+	 * Id.
 	 *
 	 * @version 2.1.8
+	 * @since   2.1.8
 	*/
-	public $id = '';   
-    public $desc = ''; 
+	public $id = '';
+
+	/**
+	 * Desc.
+	 *
+	 * @version 2.1.8
+	 * @since   2.1.8
+	 */
+    public $desc = '';
 
 	/**
 	 * Constructor.

--- a/includes/settings/class-alg-wc-guest-order-tracking-settings-section.php
+++ b/includes/settings/class-alg-wc-guest-order-tracking-settings-section.php
@@ -13,6 +13,14 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 if ( ! class_exists( 'Alg_WC_Guest_Order_Tracking_Settings_Section' ) ) :
 
 class Alg_WC_Guest_Order_Tracking_Settings_Section {
+	
+	/**
+	 * FIX: PHP 8.2+ এ dynamic property deprecated।
+	 *
+	 * @version 2.1.8
+	*/
+	public $id = '';   
+    public $desc = ''; 
 
 	/**
 	 * Constructor.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wpcodefactory, omardabbas, karzin, anbinder, kousikmukherjeeli
 Tags: woocommerce, order, tracking, unlogged, guest
 Requires at least: 4.4
-Tested up to: 6.8
-Stable tag: 2.1.7
+Tested up to: 6.9
+Stable tag: 2.1.8
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -45,6 +45,11 @@ If you are interested in contributing - head over to the [Guest Order Tracking f
 3. Start by visiting plugin settings at "WooCommerce > Settings > Guest Order Tracking".
 
 == Changelog ==
+
+= 2.1.8 - 04/04/2026 =
+* Fix - Declare $id and $desc properties explicitly to resolve PHP 8.2+ dynamic property deprecation.
+* Tested up to: 6.9
+* WC tested up to: 10.6
 
 = 2.1.7 - 08/09/2025 =
 * Tested up to: 6.8


### PR DESCRIPTION
Fix: Declare \$id and \$desc properties explicitly to resolve PHP 8.2+ dynamic property deprecation